### PR TITLE
Fix Batch Normalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytorch torchvision cuda80 numpy scipy h5py -c pytorch
-  - conda install tensorflow -c conda-forge
-  - conda install theano pygpu
+  - conda install pytorch torchvision cuda80 numpy scipy h5py -c pytorch -q
+  - conda install tensorflow -c conda-forge -q
+  - conda install theano pygpu -q
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytorch torchvision cuda80 numpy scipy h5py -c soumith
+  - conda install pytorch torchvision cuda80 numpy scipy h5py -c pytorch
   - conda install tensorflow -c conda-forge
   - conda install theano pygpu
   - python setup.py install

--- a/nn_transfer/test/architectures/simplenet.py
+++ b/nn_transfer/test/architectures/simplenet.py
@@ -5,7 +5,7 @@ import keras
 from keras import backend as K
 from keras.models import Sequential
 from keras.layers import Dense, Flatten
-from keras.layers import Conv2D, MaxPooling2D
+from keras.layers import Conv2D, MaxPooling2D, BatchNormalization
 
 K.set_image_data_format('channels_first')
 
@@ -14,10 +14,11 @@ class SimpleNetPytorch(nn.Module):
     def __init__(self):
         super(SimpleNetPytorch, self).__init__()
         self.conv1 = nn.Conv2d(1, 6, 5)
+        self.bn = nn.BatchNorm2d(6)
         self.fc1 = nn.Linear(6 * 14 * 14, 10)
 
     def forward(self, x):
-        out = F.relu(self.conv1(x))
+        out = F.relu(self.bn(self.conv1(x)))
         out = F.max_pool2d(out, 2)
         out = out.view(out.size(0), -1)
         out = self.fc1(out)
@@ -30,6 +31,7 @@ def simplenet_keras():
                      activation='relu',
                      input_shape=(1, 32, 32),
                      name='conv1'))
+    model.add(BatchNormalization(axis=1, name='bn'))
     model.add(MaxPooling2D(pool_size=(2, 2)))
     model.add(Flatten())
     model.add(Dense(10, activation=None, name='fc1'))

--- a/nn_transfer/test/helpers.py
+++ b/nn_transfer/test/helpers.py
@@ -15,6 +15,11 @@ else:
 print(TRANSFER_DIRECTION, "tests")
 
 
+def set_seeds():
+    torch.manual_seed(0)
+    np.random.seed(0)
+
+
 class TransferTestCase(object):
     def assertEqualPrediction(
             self, keras_model, pytorch_model, test_data, delta=1e-6):

--- a/nn_transfer/test/test_architectures.py
+++ b/nn_transfer/test/test_architectures.py
@@ -25,7 +25,8 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
         self.assertEqualPrediction(
             keras_model,
             pytorch_model,
-            self.test_data_small)
+            self.test_data_small,
+            delta=1e-3)  # These results can vary due to float imprecision
 
     def test_lenet(self):
         set_seeds()

--- a/nn_transfer/test/test_architectures.py
+++ b/nn_transfer/test/test_architectures.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from .helpers import TransferTestCase
+from .helpers import TransferTestCase, set_seeds
 from .architectures.lenet import lenet_keras, LeNetPytorch
 from .architectures.simplenet import simplenet_keras, SimpleNetPytorch
 from .architectures.vggnet import vggnet_keras, vggnet_pytorch
@@ -17,6 +17,7 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
         self.test_data_unet = np.random.rand(1, 1, 224, 224)
 
     def test_simplenet(self):
+        set_seeds()
         keras_model = simplenet_keras()
         pytorch_model = SimpleNetPytorch()
 
@@ -27,6 +28,7 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
             self.test_data_small)
 
     def test_lenet(self):
+        set_seeds()
         keras_model = lenet_keras()
         pytorch_model = LeNetPytorch()
 
@@ -37,6 +39,7 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
             self.test_data_small)
 
     def test_unet(self):
+        set_seeds()
         keras_model = unet_keras()
         pytorch_model = UNetPytorch()
         pytorch_model.eval()
@@ -48,6 +51,7 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
             self.test_data_unet)
 
     def test_vggnet(self):
+        set_seeds()
         keras_model = vggnet_keras()
         pytorch_model = vggnet_pytorch()
         pytorch_model.eval()

--- a/nn_transfer/test/test_architectures.py
+++ b/nn_transfer/test/test_architectures.py
@@ -15,9 +15,9 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
         self.test_data_small = np.random.rand(4, 1, 32, 32)
         self.test_data_vgg = np.random.rand(1, 3, 224, 224)
         self.test_data_unet = np.random.rand(1, 1, 224, 224)
+        set_seeds()
 
     def test_simplenet(self):
-        set_seeds()
         keras_model = simplenet_keras()
         pytorch_model = SimpleNetPytorch()
 
@@ -29,7 +29,6 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
             delta=1e-3)  # These results can vary due to float imprecision
 
     def test_lenet(self):
-        set_seeds()
         keras_model = lenet_keras()
         pytorch_model = LeNetPytorch()
 
@@ -40,7 +39,6 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
             self.test_data_small)
 
     def test_unet(self):
-        set_seeds()
         keras_model = unet_keras()
         pytorch_model = UNetPytorch()
         pytorch_model.eval()
@@ -52,7 +50,6 @@ class TestArchitectures(TransferTestCase, unittest.TestCase):
             self.test_data_unet)
 
     def test_vggnet(self):
-        set_seeds()
         keras_model = vggnet_keras()
         pytorch_model = vggnet_pytorch()
         pytorch_model.eval()

--- a/nn_transfer/transfer.py
+++ b/nn_transfer/transfer.py
@@ -17,6 +17,8 @@ KERAS_BIAS_KEY = 'bias' + VAR_AFFIX
 KERAS_BETA_KEY = 'beta' + VAR_AFFIX
 KERAS_MOVING_MEAN_KEY = 'moving_mean' + VAR_AFFIX
 KERAS_MOVING_VARIANCE_KEY = 'moving_variance' + VAR_AFFIX
+KERAS_EPSILON = 1e-3
+PYTORCH_EPSILON = 1e-5
 
 
 def check_for_missing_layers(keras_names, pytorch_layer_names, verbose):
@@ -91,6 +93,8 @@ def keras_to_pytorch(keras_model, pytorch_model,
             # Load batch normalization running variance
             if running_var_key in input_state_dict:
                 running_var = params[KERAS_MOVING_VARIANCE_KEY][:]
+                # account for difference in epsilon used
+                running_var += KERAS_EPSILON - PYTORCH_EPSILON
                 state_dict[running_var_key] = torch.from_numpy(
                     running_var.transpose())
 
@@ -156,6 +160,8 @@ def pytorch_to_keras(pytorch_model, keras_model,
             # Load batch normalization running variance
             if running_var_key in input_state_dict:
                 running_var = input_state_dict[running_var_key].numpy()
+                # account for difference in epsilon used
+                running_var += PYTORCH_EPSILON - KERAS_EPSILON
                 params[KERAS_MOVING_VARIANCE_KEY][:] = running_var
 
     # pytorch_model.load_state_dict(state_dict)


### PR DESCRIPTION
Keras uses `epsilon=1-e3` to avoid division by 0 in batch normalization. Pytorch uses `epsilon=1e-5`. This can cause a major difference in output for large networks. Fortunately, this can easily be fixed when transferring the parameters.